### PR TITLE
fix reset_counter MAVlink pack errors

### DIFF
--- a/scripts/t265_to_mavlink.py
+++ b/scripts/t265_to_mavlink.py
@@ -427,6 +427,9 @@ def realsense_notification_callback(notif):
     print("INFO: T265 event: " + notif)
     if notif.get_category() is rs.notification_category.pose_relocalization:
         reset_counter += 1
+        if reset_counter > 255:
+            reset_counter = 1
+
         send_msg_to_gcs('Relocalization detected')
 
 def realsense_connect():

--- a/scripts/t265_to_mavlink.py
+++ b/scripts/t265_to_mavlink.py
@@ -429,7 +429,6 @@ def realsense_notification_callback(notif):
         reset_counter += 1
         if reset_counter > 255:
             reset_counter = 1
-
         send_msg_to_gcs('Relocalization detected')
 
 def realsense_connect():


### PR DESCRIPTION
when reset_counter is more than 255, it will raise error in mavlink message uint8_t pack