### PR TITLE
non-ROS-t265: add velocity threshold for jump criterion

### DIFF
--- a/scripts/t265_to_mavlink.py
+++ b/scripts/t265_to_mavlink.py
@@ -578,13 +578,19 @@ try:
                 # Check for pose jump and increment reset_counter
                 if prev_data != None:
                     delta_translation = [data.translation.x - prev_data.translation.x, data.translation.y - prev_data.translation.y, data.translation.z - prev_data.translation.z]
+                    delta_velocity = [data.velocity.x - prev_data.velocity.x, data.velocity.y - prev_data.velocity.y, data.velocity.z - prev_data.velocity.z]
                     position_displacement = np.linalg.norm(delta_translation)
+                    speed_delta = np.linalg.norm(delta_velocity)
 
                     # Pose jump is indicated when position changes abruptly. The behavior is not well documented yet (as of librealsense 2.34.0)
                     jump_threshold = 0.1 # in meters, from trials and errors, should be relative to how frequent is the position data obtained (200Hz for the T265)
-                    if (position_displacement > jump_threshold):
-                        send_msg_to_gcs('Pose jump detected')
-                        print("Position jumped by: ", position_displacement)
+                    jump_speed_threshold = 20.0 # in m/s from trials and errors, should be relative to how frequent is the velocity data obtained (200Hz for the T265)
+                    if (position_displacement > jump_threshold) or (speed_delta > jump_speed_threshold):
+                        send_msg_to_gcs('VISO jump detected')
+                        if position_displacement > jump_threshold:
+                            print("Position jumped by: ", position_displacement)
+                        elif speed_delta > jump_speed_threshold:
+                            print("Speed jumped by: ", speed_delta)
                         increment_reset_counter()
                     
                 prev_data = data


### PR DESCRIPTION
Given developers still have not determined if the velocities given by T265 improve visual estimates or not, just wondered if the current “increment_reset_counter()” logic is sufficient for general case. The jump check has been done at the raw position data frequency of 200Hz and not at the output frequency of 30Hz which is set as a Python based parameter, so the velocity threshold is to be added as 20m/s (= 0.1 x 200).