### PR TITLE
d4xx_to_mavlink.py: Add RealSense D455 product ID

### DIFF
--- a/scripts/d4xx_to_mavlink.py
+++ b/scripts/d4xx_to_mavlink.py
@@ -334,7 +334,7 @@ def ahrs2_msg_callback(value):
 ##  Functions - D4xx cameras                        ##
 ######################################################
 
-DS5_product_ids = ["0AD1", "0AD2", "0AD3", "0AD4", "0AD5", "0AF6", "0AFE", "0AFF", "0B00", "0B01", "0B03", "0B07","0B3A"]
+DS5_product_ids = ["0AD1", "0AD2", "0AD3", "0AD4", "0AD5", "0AF6", "0AFE", "0AFF", "0B00", "0B01", "0B03", "0B07", "0B3A", "0B5C"]
 
 def find_device_that_supports_advanced_mode() :
     ctx = rs.context()


### PR DESCRIPTION
The camera connection to advaced mode in this script probably comes from this example here:
https://github.com/IntelRealSense/librealsense/blob/master/wrappers/python/examples/python-rs400-advanced-mode-example.py

However even there (to my suprise), the Intel RealSense D455 product ID is not listed. Therfore the D455 will never connect to the script in Thiens master (the error printed is -> _Exception: No device that supports advanced mode was found_). This simple low-risk addition will fix the issue.
I will most probably raise a similar PR in the example script above as well.