### PR TITLE
[t265_fisheye_undistort] Now builds with OpcenCV 3.X and 4.x

### DIFF
--- a/src/t265_fisheye_undistort.cpp
+++ b/src/t265_fisheye_undistort.cpp
@@ -58,7 +58,11 @@ void init_rectification_map(string param_file_path)
                 R, T, 
                 R1, R2, P1, P2, 
                 Q,
-                CV_CALIB_ZERO_DISPARITY, 
+#if CV_VERSION_MAJOR == 3
+                CALIB_ZERO_DISPARITY,
+#elif CV_VERSION_MAJOR == 4
+                cv::CALIB_ZERO_DISPARITY,
+#endif
                 alpha, 
                 output_img_size);
  


### PR DESCRIPTION
Hello,

With these changes the repository now correctly builds with ROS Noetic (OpenCV 4) and ROS Melodic (OpenCV 3).

Regards,
Lovro