### PR TITLE
fix mavros_msgs dependency for first build

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -57,6 +57,7 @@
   <build_depend>std_msgs</build_depend>
   <build_depend>image_transport</build_depend>
 
+  <build_export_depend>mavros_msgs</build_export_depend>
   <build_export_depend>roscpp</build_export_depend>
   <build_export_depend>rospy</build_export_depend>
   <build_export_depend>tf</build_export_depend>


### PR DESCRIPTION
When a clean build is performed, dependencies are not resolved correctly, leading to compilation errors if `mavros_msgs` is not yet built when `vision_to_mavros` starts its compilation.